### PR TITLE
Make the lib exportable in a Node environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ You'll see the files in the dist folder:
  
  `<ul class="prophet"></ul>`
 
+ or
+
+ `import Message from 'prophetjs'`
+
 
 # API
 

--- a/build/js/prophet.ts
+++ b/build/js/prophet.ts
@@ -223,5 +223,8 @@ class Message{
 
 }
 
-
+if (typeof module !== "undefined")
+    module["exports"] = Message;
+else
+    window["Message"] = Message;
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "prophetjs",
   "version": "1.0.0",
   "description": "A very lean dependency free javascript library to display toast messages on web pages.",
+  "main": "./dist/js/prophet.js",
   "devDependencies": {
     "gulp": "^3.9.1",
     "gulp-cssmin": "^0.1.7",


### PR DESCRIPTION
Hey there!

This PR adds a default export for Node environments (Webpack, Rollup, etc) so it can be used like 
`import Message from 'prophetjs'`